### PR TITLE
update terraform install steps, move to install script

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,11 @@
 tasks:
   - name: terraform
-    init: |
-      sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
-      curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-      sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-      sudo apt-get update && sudo apt-get install terraform
+    before: |
+      bash ./bin/install-terraform-cli
   - name: aws-cli
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
-    init: |
+    before: |
       cd /workspace
       curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       unzip awscliv2.zip

--- a/bin/install-terraform-cli
+++ b/bin/install-terraform-cli
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+sudo apt-get update && sudo apt-get install -y gnupg curl software-properties-common
+
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+gpg --quiet --dearmor | \
+sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+gpg --no-default-keyring \
+--keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+--fingerprint
+
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+sudo apt update && sudo apt-get install -y  terraform


### PR DESCRIPTION
- terraform cli had a deprecation related to gpg key, update installation steps from https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli for linux

- move steps to an install script